### PR TITLE
fix missing s on property of zenpy client class

### DIFF
--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -195,7 +195,7 @@ class OrganizationFields(Stream):
     def sync(self, state):
         bookmark = self.get_bookmark(state)
 
-        fields = self.client.organization_field()
+        fields = self.client.organization_fields()
         for field in fields:
             if field.updated_at:
                 if utils.strptime_with_tz(field.updated_at) >= bookmark:


### PR DESCRIPTION
tested again locally

![image](https://user-images.githubusercontent.com/5045714/204822813-7afef01e-4e0c-4717-9dc9-cd3586e5a915.png)

It will result the catalog with stream organization_fields
![image](https://user-images.githubusercontent.com/5045714/204822911-f8d081d3-0966-4b35-83db-128b95dccf53.png)
