### PR TITLE
fix wrong column name

### DIFF
--- a/tap_zendesk/schemas/organization_fields.json
+++ b/tap_zendesk/schemas/organization_fields.json
@@ -1,6 +1,6 @@
 {
     "properties": {
-        "default": {
+        "active": {
             "type": [
                 "null",
                 "boolean"
@@ -125,7 +125,8 @@
             "type": [
                 "null",
                 "string"
-            ]
+            ],
+            "format": "date-time"
         },
         "url": {
             "type": [


### PR DESCRIPTION
the column should be the same as here.
There is no column default, but only column active.
https://developer.zendesk.com/api-reference/ticketing/organizations/organization_fields/